### PR TITLE
Fix deployed GitHub pages URL

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+hackpompey.co.uk


### PR DESCRIPTION
Every deployment overrides the URL in the settings from hackpompey.co.uk to hackpompey.github.io, which causes the site to be inaccessible from the main domain

This PR includes a CNAME file in the static asset folder that gets copied to the root build directory, which will keep the deployed URL as hackpompey.co.uk (per gh-pages spec, the deployed site needs a "CNAME" file containing only the deployment url if you're not using github actions [[ref]](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/troubleshooting-custom-domains-and-github-pages#cname-errors))